### PR TITLE
golangci-lint: fix types and minimum values

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -483,7 +483,7 @@
             },
             "package-average": {
               "description": "Max average complexity in package",
-              "type": "integer",
+              "type": "number",
               "default": 0.0,
               "minimum": 0.0
             }
@@ -524,7 +524,7 @@
             "list-type": {
               "description": "List kind (`allowlist` or `denylist`)",
               "enum": ["allowlist", "denylist", "blacklist", "whitelist"],
-              "default": "blacklist"
+              "default": "denylist"
             },
             "include-go-root": {
               "description": "Whether to check the list against the standard lib.",
@@ -745,14 +745,12 @@
             "lines": {
               "description": "Limit lines number per function.",
               "type": "integer",
-              "default": 60,
-              "minimum": 1
+              "default": 60
             },
             "statements": {
               "description": "Limit statements number per function",
               "type": "integer",
-              "default": 40,
-              "minimum": 1
+              "default": 40
             }
           }
         },


### PR DESCRIPTION
- set the type `number` for float values
- set `denylist` as default
- `lines` and `statements` can be negative integer
